### PR TITLE
Feature #19: a user can now create a new composition with fine-grained limits

### DIFF
--- a/src/conductor/conductor.py
+++ b/src/conductor/conductor.py
@@ -71,7 +71,7 @@ def synthesize(composition): # dict
         { 'key': 'provide-api-key', 'value': True }
     ]
 
-    return { 'name': composition['name'], 'action': { 'exec': { 'kind': 'python:3', 'code':code }, 'annotations': annotations } }
+    return { 'name': composition['name'], 'action': { 'exec': { 'kind': 'python:3', 'code':code }, 'annotations': annotations, 'limits': composition['limits'] } }
 
 def openwhisk(options):
     ''' return enhanced openwhisk client capable of deploying compositions '''


### PR DESCRIPTION
Made changes so a user can create a new composition with fine-grained limits. For instance, a user can do so with the following commands:
```bash
$ <composition> <composition.json> --limits '{"concurrency": 30}'
$ <composition> <composition.json> --limits-file limits.json
# where limits.json has, for instance, the contents '{"logs": 5, "concurrency": 30}'
```

Moreover, I also did some necessary refactoring to the `pydeploy` code: fixed the raises (it is necessary to create a `BaseException` object), created the `key_value_arg_verification` with duplicated code in the below functions, and used [black](https://pypi.org/project/black/) to prettify the overall code.